### PR TITLE
Add LastPassify executable to ./exe/ dir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed the loading of the LastPassify executable.
+
 ## [0.4.2]
 
 - Updates to dependencies

--- a/exe/lastpassify
+++ b/exe/lastpassify
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift("#{__dir__}/../lib")
+
+require "lastpassify"
+
+LastPassify::Runner.new(ARGV).execute!

--- a/lastpassify.gemspec
+++ b/lastpassify.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.3.0"

--- a/lib/lastpassify.rb
+++ b/lib/lastpassify.rb
@@ -1,0 +1,3 @@
+require_relative "./lastpassify/version"
+require_relative "./lastpassify/runner"
+require_relative "./lastpassify/lastpassify"


### PR DESCRIPTION
This change adds configuration to our gemspec to load the executable
from the `./exe/` directory.

Co-authored-by: Ian Whitney <whit0694@umn.edu>
Co-authored-by: Remy Abdullahi <abdu0299@umn.edu>