### PR TITLE
Add a check for lpass login

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [Added]
+- Tests now ensure you are logged in to lastpass before running
+
 ## [0.4.3]
 
 - Fixed the loading of the LastPassify executable.

--- a/spec/lib/lastpassify_spec.rb
+++ b/spec/lib/lastpassify_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe LastPassify::LastPassify, type: :aruba do
     let(:input) { "database.example.yml" }
     let(:output) { "config/database.yml" }
 
+    before :all do
+      status = system("lpass status -q")
+      unless status
+        raise(StandardError, "Please log in to lastpass with lpass login")
+      end
+    end
+
     before :each do
       copy "%/database.example.yml", "database.example.yml"
     end


### PR DESCRIPTION
If you run the test suite and you are not logged in you get failures.
But the test failures don't tell you that logging in will fix them.
Adding a single task that runs before the test suite to check if you are
logged in.

Co-authored-by: Ian Whitney <whit0694@umn.edu>
Co-authored-by: Remy Abdullahi <abdu0299@umn.edu>