### PR TITLE
Remove update before every test run

### DIFF
--- a/script/test
+++ b/script/test
@@ -12,8 +12,6 @@ cd "$(dirname "$0")/.."
 
 export ENV="test"
 
-script/update
-
 echo "===> Running tests..."
 
 if [ -n "$1" ]; then


### PR DESCRIPTION
`script/update` ends up updating Brew formulas, which is very slow and
not relevant to test runs. Removing this so that `script/test` just runs
tests.

Co-authored-by: Ian Whitney <whit0694@umn.edu>
Co-authored-by: Remy Abdullahi <abdu0299@umn.edu>