### PR TITLE
Update Lastpassify gems and syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in comment_builder.gemspec
+# Specify your gem's dependencies in lastpassify.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lastpassify (0.4.3)
+    lastpassify (0.5.0)
       thor
 
 GEM
@@ -84,7 +84,7 @@ GEM
       psych (~> 3.1)
       rainbow (>= 2.0, < 4.0)
     regexp_parser (2.0.3)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -120,7 +120,7 @@ GEM
       ffi (~> 1.1)
     thor (1.1.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
 
@@ -139,4 +139,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.2.6
+   2.2.23

--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `rexml` and `tzinfo` gems for CVEs
+- Fix comment in `Gemfile`
+- Alphabetize dependencies in `gemspec`
+
 ## [0.5.0]
 
-### [Added]
+### Added
 - Tests now ensure you are logged in to lastpass before running
   - https://github.com/umn-asr/lastpassify/issues/9
 
-### [Fixed]
+### Fixed
 - Unable to see that lpass is installed
   - https://github.com/umn-asr/lastpassify/issues/12
 

--- a/lastpassify.gemspec
+++ b/lastpassify.gemspec
@@ -22,13 +22,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
+  spec.add_development_dependency "aruba", "~> 0.14.2"
+  spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "bundler-audit"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "standard"
   spec.add_development_dependency "reek"
-  spec.add_development_dependency "awesome_print"
-  spec.add_development_dependency "aruba", "~> 0.14.2"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "standard"
+
   spec.add_dependency "thor"
 end


### PR DESCRIPTION
While looking at updating `lastpassify` to allow for use with Ruby 3, I found some small issues that I thought would be nice to fix while I'm working on the project. They are all pretty disparate but small changes, so I kept them as separate commits. The biggest change is likely the fix for a couple of CVEs.

- fc5d833392689d9b79db2f6778e2ae80714e2a38: Fix CVEs, update version of lastpassify
- 0da883de40e20498fa01e167adfd3779583c340b: Fix comment in Gemfile to match project name
- 29786e652de220deee7152a680c1be9fa6ece511: Arrange gems in alphabetical order
- e3b5a06a09a8a19ebce2ec32b31d6d440824c0fa: Update changelog