### PR TITLE
Log into lastpass for tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -12,6 +12,21 @@ cd "$(dirname "$0")/.."
 
 export ENV="test"
 
+set +e
+
+echo "===> Checking if logged into lastpass..."
+
+LPASS_STATUS="$(lpass status)"
+echo $LPASS_STATUS
+
+if [ "${LPASS_STATUS}" = 'Not logged in.' ]; then
+  lpass_username="$USER@umn.edu"
+  `lpass login $lpass_username >/dev/null`
+  echo "Logged into lastpass."
+fi
+
+set -e
+
 echo "===> Running tests..."
 
 if [ -n "$1" ]; then


### PR DESCRIPTION
The tests for this gem require that you're logged into lastpass. A few times when running them, I briefly thought I broke everything because they fail if you're not logged in.

Adding a piece to the test script to check if the user is logged in, and if not, log them in.

As we've found before in our Change of College private repo, we need to use `set +e`:

> When the LP check came back 'Not logged in' this counted as an error,
> and the whole script stopped.
> The set -e at the top of the script enables automatic exit on
> error. So we add set +e to allow errors without exiting the script.
> After the LP check is complete, we re-enable this.