### PR TITLE
Make LastPassify compatible with Psych 4, add byebug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Thumbs.db
 *.swp
 tmp/
 bin/
+.byebug_history

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     bundler-audit (0.7.0.1)
       bundler (>= 1.2.0, < 3)
       thor (>= 0.18, < 2)
+    byebug (11.1.3)
     childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     contracts (0.16.0)
@@ -132,6 +133,7 @@ DEPENDENCIES
   awesome_print
   bundler (~> 2.0)
   bundler-audit
+  byebug
   lastpassify!
   rake
   reek

--- a/changelog.md
+++ b/changelog.md
@@ -6,11 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `byebug` as a development dependency
+
+### Changed
+
+- Lastpassify should now be compatible with projects using Psych 4 and above
+
 ### Fixed
 
 - Update `rexml` and `tzinfo` gems for CVEs
 - Fix comment in `Gemfile`
 - Alphabetize dependencies in `gemspec`
+- Prompt user to login to LastPass when running tests
 
 ## [0.5.0]
 

--- a/lastpassify.gemspec
+++ b/lastpassify.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "awesome_print"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "bundler-audit"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "reek"
   spec.add_development_dependency "rspec"

--- a/lib/lastpassify/lastpassify.rb
+++ b/lib/lastpassify/lastpassify.rb
@@ -27,8 +27,16 @@ module LastPassify
     def main
       raise LPassNotInstalled, "Please install LastPass-CLI - https://github.com/lastpass/lastpass-cli" unless lastpass_installed?
 
+      current_psych_version = Gem::Version.new(Psych::VERSION)
+      psych_version_requiring_named_args = Gem::Version.new("4.0.0")
+
       template input_file, output_file do |content|
-        yml = YAML.safe_load content, [], [], true
+        yml = if current_psych_version >= psych_version_requiring_named_args
+          YAML.safe_load content, aliases: true
+        else
+          YAML.safe_load content, [], [], true
+        end
+
         delete_staging(yml) unless options[:staging]
         delete_production(yml) unless options[:production]
         content = YAML.dump(yml)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require_relative "../lib/lastpassify/runner"
 require "bundler/setup"
 require "aruba/rspec"
+require "byebug"


### PR DESCRIPTION
The main change here is db2d8bfa9dd8885baea2996bd3c3f50f2fa759fa.

When trying to upgrade another project using LastPassify to Ruby 3, we saw this error:

```
ruby/3.1.0/psych.rb:323:in `safe_load': wrong number of arguments (given 4, expected 1) (ArgumentError)
```

We found that [Psych had changed its interface to use named arguments](https://github.com/ruby/psych/commit/176494297f3f124467a6e3f1c9e6400ee742d663)
for `safe_load` in Psych 4. So this code looks at what the current Psych
version is to see if it's 4 or above, and then calls `safe_load` with or
without named arguments, depending on what the current version is.

We did this so that lastpassify could remain backwards compatible but
also work as we move more applications to Ruby 3.

One alternative presented was to use `unsafe_load` but that felt risky
since it's a gem used in many projects.

We had to make each of the variables `Gem::Version.new` so that we'd be
comparing `versions` and not strings. I myself got a little confused
when I saw Bundler version `2.2.23` was newer than `2.2.6`. String
comparison would make the same mistake I did, so we needed `versions`
to be able to semantically compare them.

I was surprised to find `Psych::VERSION` returned a string, not a
`version`, causing the tests to error because it couldn't compare a
version against a string. This is why both of the variables needed to
use `Gem::Version.new`.

Finally, we [add `byebug`](da1291639ff9fbfa5c4eff36592978fff7703067) and [update the changelog](58031498f6996a814c418ee019fa9dddf7a2ec08).

Co-authored-by: Brittany Greaner <grea0022@umn.edu>
Co-authored-by: Davin Lagerroos <dlagerro@umn.edu>